### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,28 @@
 {
   "name": "suitcss-utils-flex",
-  "description": "Flexbox utilities for SUIT CSS",
   "version": "1.1.1",
-  "style": "index.css",
+  "description": "Flexbox utilities for SUIT CSS",
+  "keywords": [
+    "browser",
+    "css-utilities",
+    "flex",
+    "flexbox",
+    "suitcss",
+    "style"
+  ],
+  "homepage": "https://github.com/suitcss/utils-flex#readme",
+  "bugs": "https://github.com/suitcss/utils-flex/labels/bug",
+  "license": "MIT",
+  "author": "Simon Smith",
   "files": [
     "index.css",
     "index.js",
     "lib"
   ],
-  "devDependencies": {
-    "stylelint-config-suitcss": "^4.0.0",
-    "suitcss-components-test": "*",
-    "suitcss-preprocessor": "^1.0.0",
-    "suitcss-utils-display": "^1.0.0",
-    "suitcss-utils-size": "^1.0.0"
+  "style": "index.css",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/utils-flex"
   },
   "scripts": {
     "build": "npm run setup && npm run preprocess",
@@ -25,17 +34,11 @@
     "watch": "npm run preprocess-test -- -w -v",
     "test": "npm run lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/suitcss/utils-flex"
-  },
-  "keywords": [
-    "browser",
-    "css-utilities",
-    "flex",
-    "flexbox",
-    "suitcss",
-    "style"
-  ],
-  "dependencies": {}
+  "devDependencies": {
+    "stylelint-config-suitcss": "^4.0.0",
+    "suitcss-components-test": "*",
+    "suitcss-preprocessor": "^1.0.0",
+    "suitcss-utils-display": "^1.0.0",
+    "suitcss-utils-size": "^1.0.0"
+  }
 }


### PR DESCRIPTION
I noticed some inconsistencies and omissions in suit package info, so I tidied up:

* Arrange the package objects to match the order found in https://docs.npmjs.com/files/package.json.
* Add a `homepage` object with a link to the project’s readme on GitHub.
* Add a `bugs` object with a link to the project’s issues labeled `bug` on GitHub.
* Add an `author` object with the name of the project’s author.
* Clean up any mistakes or omissions